### PR TITLE
feat: rotating logs

### DIFF
--- a/examples/log_rotation_example.py
+++ b/examples/log_rotation_example.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating log rotation functionality in Imitator
+
+This script shows how to configure and use log rotation to manage
+file sizes automatically when they exceed preset limits.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+# Add the parent directory to the path so we can import imitator
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from imitator import monitor_function, LocalStorage, get_monitor
+
+
+def cleanup_logs():
+    """Clean up example log files"""
+    log_dir = Path("rotation_logs")
+    if log_dir.exists():
+        for file in log_dir.glob("*.jsonl"):
+            file.unlink()
+        log_dir.rmdir()
+
+
+@monitor_function(
+    # Set small limits for demonstration
+    max_file_size_mb=0.001,  # 1KB for demo purposes
+    rotation_batch_size=5    # Remove 5 entries when rotating
+)
+def example_function(x: int, y: str = "default") -> dict:
+    """Example function that generates logs"""
+    return {
+        "result": x * 2,
+        "message": f"Processed {x} with {y}",
+        "timestamp": time.time()
+    }
+
+
+def demonstrate_rotation():
+    """Demonstrate log rotation in action"""
+    print("🔄 Log Rotation Demonstration")
+    print("=" * 50)
+    
+    # Clean up any existing logs
+    cleanup_logs()
+    
+    # Create storage with custom settings
+    storage = LocalStorage(
+        log_dir="rotation_logs",
+        max_file_size_mb=0.001,  # 1KB for demo
+        rotation_batch_size=3
+    )
+    
+    print(f"📊 Initial rotation settings:")
+    settings = storage.get_rotation_settings()
+    print(f"   Max file size: {settings['max_file_size_mb']:.3f} MB")
+    print(f"   Rotation batch size: {settings['rotation_batch_size']}")
+    print()
+    
+    # Create monitor with custom storage
+    monitor = get_monitor(
+        storage=storage,
+        max_file_size_mb=0.001,
+        rotation_batch_size=3
+    )
+    
+    @monitor.monitor
+    def test_function(value: int) -> str:
+        """Test function for rotation demo"""
+        return f"Result for {value}: {'x' * 100}"  # Larger output to increase file size
+    
+    print("📝 Generating log entries...")
+    
+    # Generate entries and monitor file growth
+    for i in range(20):
+        test_function(i)
+        
+        # Check file info every few entries
+        if i % 3 == 0:
+            info = storage.get_log_file_info("test_function")
+            print(f"   Entry {i:2d}: {info['size_bytes']:4d} bytes, "
+                  f"{info['entry_count']:2d} entries, "
+                  f"rotation needed: {info['rotation_needed']}")
+            
+            if info['rotation_needed'] and info['entries_until_rotation'] <= 3:
+                print(f"   🔄 Rotation will happen soon! "
+                      f"({info['entries_until_rotation']} entries until rotation)")
+    
+    print()
+    print("📈 Final file information:")
+    info = storage.get_log_file_info("test_function")
+    for key, value in info.items():
+        print(f"   {key}: {value}")
+    
+    print()
+    print("🔧 Manual rotation demonstration:")
+    print(f"   Entries before manual rotation: {info['entry_count']}")
+    
+    # Force a manual rotation
+    success = storage.force_rotate_log("test_function", entries_to_remove=5)
+    if success:
+        info_after = storage.get_log_file_info("test_function")
+        print(f"   Entries after removing 5: {info_after['entry_count']}")
+        print(f"   File size reduced from {info['size_bytes']} to {info_after['size_bytes']} bytes")
+    
+    print()
+    print("📋 All monitored functions:")
+    all_info = storage.get_all_log_files_info()
+    for func_name, func_info in all_info.items():
+        print(f"   {func_name}: {func_info['entry_count']} entries, "
+              f"{func_info['size_mb']:.3f} MB")
+
+
+def demonstrate_settings_management():
+    """Demonstrate how to manage rotation settings"""
+    print("\n⚙️  Settings Management Demonstration")
+    print("=" * 50)
+    
+    storage = LocalStorage()
+    
+    print("📊 Default settings:")
+    settings = storage.get_rotation_settings()
+    for key, value in settings.items():
+        print(f"   {key}: {value}")
+    
+    print("\n🔧 Updating settings...")
+    storage.set_rotation_settings(
+        max_file_size_mb=100.0,  # 100MB
+        rotation_batch_size=100  # Remove 100 entries at a time
+    )
+    
+    print("📊 Updated settings:")
+    settings = storage.get_rotation_settings()
+    for key, value in settings.items():
+        print(f"   {key}: {value}")
+
+
+def demonstrate_info_queries():
+    """Demonstrate querying log file information"""
+    print("\n📊 Log Information Queries")
+    print("=" * 50)
+    
+    # Generate some sample data first
+    storage = LocalStorage(log_dir="info_demo_logs")
+    
+    @monitor_function(storage=storage)
+    def sample_func(n: int) -> dict:
+        return {"value": n, "squared": n**2}
+    
+    # Generate some entries
+    for i in range(10):
+        sample_func(i)
+    
+    print("📄 Single function info:")
+    info = storage.get_log_file_info("sample_func")
+    for key, value in info.items():
+        print(f"   {key}: {value}")
+    
+    print("\n📚 All functions info:")
+    all_info = storage.get_all_log_files_info()
+    for func_name, func_info in all_info.items():
+        print(f"   {func_name}:")
+        print(f"     - Entries: {func_info['entry_count']}")
+        print(f"     - Size: {func_info['size_mb']:.3f} MB")
+        print(f"     - Rotation needed: {func_info['rotation_needed']}")
+    
+    # Clean up
+    cleanup_demo_logs("info_demo_logs")
+
+
+def cleanup_demo_logs(log_dir: str):
+    """Clean up demonstration log files"""
+    log_path = Path(log_dir)
+    if log_path.exists():
+        for file in log_path.glob("*.jsonl"):
+            file.unlink()
+        log_path.rmdir()
+
+
+if __name__ == "__main__":
+    try:
+        demonstrate_rotation()
+        demonstrate_settings_management()
+        demonstrate_info_queries()
+        
+        print("\n✅ Log rotation demonstration completed!")
+        print("\n💡 Key takeaways:")
+        print("   • Log files automatically rotate when they exceed size limits")
+        print("   • Rotation removes oldest entries in configurable batches")
+        print("   • You can monitor file sizes and entry counts in real-time")
+        print("   • Manual rotation is available when needed")
+        print("   • Settings can be adjusted at runtime")
+        
+    finally:
+        # Clean up all demo files
+        cleanup_logs()
+        cleanup_demo_logs("info_demo_logs")
+        print("\n🧹 Demo files cleaned up.") 

--- a/imitator/__init__.py
+++ b/imitator/__init__.py
@@ -5,7 +5,7 @@ A powerful yet simple framework for monitoring function I/O, tracking performanc
 and collecting data for machine learning, debugging, and analysis.
 """
 
-from .monitor import monitor_function, FunctionMonitor
+from .monitor import monitor_function, FunctionMonitor, get_monitor
 from .types import FunctionCall, IORecord, FunctionSignature
 from .storage import LocalStorage
 
@@ -18,6 +18,7 @@ __description__ = "A lightweight Python framework for monitoring function I/O wi
 __all__ = [
     "monitor_function",
     "FunctionMonitor", 
+    "get_monitor",
     "FunctionCall",
     "IORecord",
     "FunctionSignature",

--- a/imitator/storage.py
+++ b/imitator/storage.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 from typing import List, Optional
 from datetime import datetime
+import tempfile
 
 from .types import FunctionCall
 
@@ -14,28 +15,122 @@ from .types import FunctionCall
 class LocalStorage:
     """Local file-based storage for function call logs"""
     
-    def __init__(self, log_dir: str = "logs", format: str = "jsonl"):
+    def __init__(self, log_dir: str = "logs", format: str = "jsonl", 
+                 max_file_size_mb: float = 50.0, rotation_batch_size: int = 50):
         """
         Initialize local storage
         
         Args:
             log_dir: Directory to store log files
             format: File format ('jsonl' or 'json')
+            max_file_size_mb: Maximum file size in MB before rotation (default: 50MB)
+            rotation_batch_size: Number of entries to remove when rotating (default: 50)
         """
         self.log_dir = Path(log_dir)
         self.format = format
+        self.max_file_size_bytes = int(max_file_size_mb * 1024 * 1024)  # Convert MB to bytes
+        self.rotation_batch_size = rotation_batch_size
         self.log_dir.mkdir(exist_ok=True)
+        
+        # Counter to track new entries since last rotation check
+        self._entry_counter = {}
         
     def _get_log_file(self, function_name: str) -> Path:
         """Get log file path for a function"""
         timestamp = datetime.now().strftime("%Y%m%d")
         return self.log_dir / f"{function_name}_{timestamp}.{self.format}"
     
+    def _get_file_size(self, file_path: Path) -> int:
+        """Get file size in bytes"""
+        return file_path.stat().st_size if file_path.exists() else 0
+    
+    def _count_jsonl_entries(self, file_path: Path) -> int:
+        """Count the number of entries in a JSONL file"""
+        if not file_path.exists():
+            return 0
+        
+        count = 0
+        with open(file_path, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip():  # Only count non-empty lines
+                    count += 1
+        return count
+    
+    def _rotate_jsonl_file(self, file_path: Path, entries_to_remove: int) -> None:
+        """
+        Rotate a JSONL file by removing the oldest entries
+        
+        Args:
+            file_path: Path to the JSONL file
+            entries_to_remove: Number of oldest entries to remove
+        """
+        if not file_path.exists():
+            return
+        
+        # Read all lines
+        lines = []
+        with open(file_path, "r", encoding="utf-8") as f:
+            lines = [line for line in f if line.strip()]  # Skip empty lines
+        
+        # If we have fewer lines than entries to remove, clear the file
+        if len(lines) <= entries_to_remove:
+            file_path.write_text("", encoding="utf-8")
+            return
+        
+        # Keep only the lines after removing the oldest entries
+        remaining_lines = lines[entries_to_remove:]
+        
+        # Write back to file atomically using a temporary file
+        with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', 
+                                       dir=file_path.parent, delete=False) as temp_file:
+            for line in remaining_lines:
+                temp_file.write(line)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+            temp_path = temp_file.name
+        
+        # Atomically replace the original file
+        os.replace(temp_path, file_path)
+    
+    def _should_rotate(self, file_path: Path, function_name: str) -> bool:
+        """
+        Check if file rotation should be performed
+        
+        Args:
+            file_path: Path to the log file
+            function_name: Name of the function (for tracking entry count)
+            
+        Returns:
+            True if rotation should be performed
+        """
+        # Check if file exceeds size limit
+        if self._get_file_size(file_path) < self.max_file_size_bytes:
+            return False
+        
+        # Initialize counter if not exists
+        if function_name not in self._entry_counter:
+            self._entry_counter[function_name] = 0
+        
+        # Increment counter for this new entry
+        self._entry_counter[function_name] += 1
+        
+        # Check if we've reached the rotation batch size
+        if self._entry_counter[function_name] >= self.rotation_batch_size:
+            self._entry_counter[function_name] = 0  # Reset counter
+            return True
+        
+        return False
+    
     def save_call(self, function_call: FunctionCall) -> None:
         """Save a function call to storage"""
         log_file = self._get_log_file(function_call.function_signature.name)
+        function_name = function_call.function_signature.name
         
         if self.format == "jsonl":
+            # Check if rotation is needed before writing
+            if self._should_rotate(log_file, function_name):
+                self._rotate_jsonl_file(log_file, self.rotation_batch_size)
+            
             # Append to JSONL file
             with open(log_file, "a", encoding="utf-8") as f:
                 f.write(function_call.model_dump_json() + "\n")
@@ -52,6 +147,10 @@ class LocalStorage:
                     calls = []
             
             calls.append(function_call.model_dump())
+            
+            # For JSON format, implement rotation by keeping only recent entries
+            if len(calls) > self.rotation_batch_size * 2 and self._get_file_size(log_file) > self.max_file_size_bytes:
+                calls = calls[-self.rotation_batch_size:]  # Keep only the most recent entries
             
             with open(log_file, "w", encoding="utf-8") as f:
                 json.dump(calls, f, indent=2, default=str)
@@ -103,4 +202,140 @@ class LocalStorage:
             if match:
                 function_name = match.group(1)
                 functions.add(function_name)
-        return list(functions) 
+        return list(functions)
+    
+    def get_log_file_info(self, function_name: str, date: Optional[str] = None) -> dict:
+        """
+        Get information about a log file
+        
+        Args:
+            function_name: Name of the function
+            date: Date in YYYYMMDD format, if None uses today
+            
+        Returns:
+            Dictionary with file information including size, entry count, etc.
+        """
+        if date is None:
+            date = datetime.now().strftime("%Y%m%d")
+        
+        log_file = self.log_dir / f"{function_name}_{date}.{self.format}"
+        
+        info = {
+            "file_path": str(log_file),
+            "exists": log_file.exists(),
+            "size_bytes": 0,
+            "size_mb": 0.0,
+            "entry_count": 0,
+            "rotation_needed": False,
+            "entries_until_rotation": self.rotation_batch_size
+        }
+        
+        if log_file.exists():
+            size_bytes = self._get_file_size(log_file)
+            info.update({
+                "size_bytes": size_bytes,
+                "size_mb": round(size_bytes / (1024 * 1024), 2),
+                "entry_count": self._count_jsonl_entries(log_file) if self.format == "jsonl" else self._count_json_entries(log_file),
+                "rotation_needed": size_bytes >= self.max_file_size_bytes,
+                "entries_until_rotation": self.rotation_batch_size - self._entry_counter.get(function_name, 0)
+            })
+        
+        return info
+    
+    def _count_json_entries(self, file_path: Path) -> int:
+        """Count the number of entries in a JSON array file"""
+        if not file_path.exists():
+            return 0
+        
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                return len(data) if isinstance(data, list) else 1
+        except (json.JSONDecodeError, FileNotFoundError):
+            return 0
+    
+    def get_all_log_files_info(self) -> dict:
+        """
+        Get information about all log files
+        
+        Returns:
+            Dictionary mapping function names to their log file information
+        """
+        functions = self.get_all_functions()
+        return {func: self.get_log_file_info(func) for func in functions}
+    
+    def force_rotate_log(self, function_name: str, date: Optional[str] = None, entries_to_remove: Optional[int] = None) -> bool:
+        """
+        Force rotation of a specific log file
+        
+        Args:
+            function_name: Name of the function
+            date: Date in YYYYMMDD format, if None uses today
+            entries_to_remove: Number of entries to remove, if None uses rotation_batch_size
+            
+        Returns:
+            True if rotation was performed, False if file doesn't exist
+        """
+        if date is None:
+            date = datetime.now().strftime("%Y%m%d")
+        
+        log_file = self.log_dir / f"{function_name}_{date}.{self.format}"
+        
+        if not log_file.exists():
+            return False
+        
+        entries_to_remove = entries_to_remove or self.rotation_batch_size
+        
+        if self.format == "jsonl":
+            self._rotate_jsonl_file(log_file, entries_to_remove)
+        else:
+            # For JSON format, rotate by keeping only recent entries
+            try:
+                with open(log_file, "r", encoding="utf-8") as f:
+                    calls = json.load(f)
+                
+                if len(calls) > entries_to_remove:
+                    calls = calls[entries_to_remove:]
+                    with open(log_file, "w", encoding="utf-8") as f:
+                        json.dump(calls, f, indent=2, default=str)
+                        f.flush()
+                        os.fsync(f.fileno())
+                else:
+                    # Clear the file if we're removing all entries
+                    log_file.write_text("[]", encoding="utf-8")
+            except (json.JSONDecodeError, FileNotFoundError):
+                return False
+        
+        # Reset entry counter for this function
+        self._entry_counter[function_name] = 0
+        
+        return True
+    
+    def set_rotation_settings(self, max_file_size_mb: Optional[float] = None, 
+                            rotation_batch_size: Optional[int] = None) -> None:
+        """
+        Update rotation settings
+        
+        Args:
+            max_file_size_mb: New maximum file size in MB
+            rotation_batch_size: New rotation batch size
+        """
+        if max_file_size_mb is not None:
+            self.max_file_size_bytes = int(max_file_size_mb * 1024 * 1024)
+        
+        if rotation_batch_size is not None:
+            self.rotation_batch_size = rotation_batch_size
+    
+    def get_rotation_settings(self) -> dict:
+        """
+        Get current rotation settings
+        
+        Returns:
+            Dictionary with current rotation settings
+        """
+        return {
+            "max_file_size_mb": self.max_file_size_bytes / (1024 * 1024),
+            "max_file_size_bytes": self.max_file_size_bytes,
+            "rotation_batch_size": self.rotation_batch_size,
+            "entry_counters": dict(self._entry_counter)
+        } 

--- a/tests/test_log_rotation.py
+++ b/tests/test_log_rotation.py
@@ -1,0 +1,202 @@
+"""
+Test cases for log rotation functionality
+"""
+
+import pytest
+import tempfile
+import shutil
+from pathlib import Path
+import time
+import threading
+
+from imitator import LocalStorage, monitor_function, get_monitor
+
+
+class TestLogRotation:
+    """Test log rotation functionality"""
+    
+    def setup_method(self):
+        """Set up test environment"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.storage = LocalStorage(
+            log_dir=self.temp_dir,
+            max_file_size_mb=0.001,  # 1KB for testing
+            rotation_batch_size=3
+        )
+    
+    def teardown_method(self):
+        """Clean up test environment"""
+        # Wait a moment for any async operations to complete
+        time.sleep(0.1)
+        try:
+            shutil.rmtree(self.temp_dir)
+        except FileNotFoundError:
+            pass  # Directory already cleaned up
+    
+    def test_file_size_detection(self):
+        """Test file size detection"""
+        # Create a test function
+        @monitor_function(storage=self.storage)
+        def test_func(data: str) -> str:
+            return f"Processed: {data}"
+        
+        # Generate enough data to exceed size limit
+        large_data = "x" * 200  # Large string to increase file size
+        for i in range(10):
+            test_func(large_data)
+        
+        # Wait for async saves to complete
+        time.sleep(0.1)
+        
+        # Check file info
+        info = self.storage.get_log_file_info("test_func")
+        assert info["exists"]
+        assert info["size_bytes"] > 0
+        assert info["entry_count"] > 0
+    
+    def test_rotation_settings(self):
+        """Test rotation settings management"""
+        # Check default settings (use approximate comparison for floating point)
+        settings = self.storage.get_rotation_settings()
+        assert abs(settings["max_file_size_mb"] - 0.001) < 0.0001
+        assert settings["rotation_batch_size"] == 3
+        
+        # Update settings
+        self.storage.set_rotation_settings(
+            max_file_size_mb=0.002,
+            rotation_batch_size=5
+        )
+        
+        updated_settings = self.storage.get_rotation_settings()
+        assert abs(updated_settings["max_file_size_mb"] - 0.002) < 0.0001
+        assert updated_settings["rotation_batch_size"] == 5
+    
+    def test_manual_rotation(self):
+        """Test manual log rotation"""
+        # Use larger limits to prevent automatic rotation during test
+        storage = LocalStorage(
+            log_dir=self.temp_dir,
+            max_file_size_mb=1.0,  # 1MB - large enough to prevent auto-rotation
+            rotation_batch_size=3
+        )
+        
+        # Create entries
+        @monitor_function(storage=storage)
+        def test_func(value: int) -> dict:
+            return {"value": value, "data": "x" * 10}  # Smaller data
+        
+        # Generate entries
+        for i in range(10):
+            test_func(i)
+        
+        # Wait for async saves
+        time.sleep(0.1)
+        
+        # Check initial count
+        info_before = storage.get_log_file_info("test_func")
+        initial_count = info_before["entry_count"]
+        assert initial_count == 10
+        
+        # Force rotation
+        success = storage.force_rotate_log("test_func", entries_to_remove=5)
+        assert success
+        
+        # Check after rotation
+        info_after = storage.get_log_file_info("test_func")
+        assert info_after["entry_count"] == initial_count - 5
+    
+    def test_automatic_rotation(self):
+        """Test automatic rotation when size limit is exceeded"""
+        # Create monitor with very small size limit
+        monitor = get_monitor(
+            storage=LocalStorage(
+                log_dir=self.temp_dir,
+                max_file_size_mb=0.0005,  # Very small limit
+                rotation_batch_size=2
+            )
+        )
+        
+        @monitor.monitor
+        def test_func(data: str) -> str:
+            return f"Large output: {data * 100}"  # Create large output
+        
+        # Generate entries - some should trigger rotation
+        for i in range(15):
+            test_func(f"data_{i}")
+        
+        # Wait for async saves and rotations
+        time.sleep(0.2)
+        
+        # File should exist and rotation should have occurred
+        final_info = monitor.storage.get_log_file_info("test_func")
+        assert final_info["exists"]
+        # Due to rotation, final count should be less than total entries generated
+        assert final_info["entry_count"] < 15
+    
+    def test_get_all_log_files_info(self):
+        """Test getting information for all log files"""
+        # Use larger limits to prevent rotation
+        storage = LocalStorage(
+            log_dir=self.temp_dir,
+            max_file_size_mb=1.0,
+            rotation_batch_size=50
+        )
+        
+        # Create multiple functions
+        @monitor_function(storage=storage)
+        def func1(x: int) -> int:
+            return x * 2
+        
+        @monitor_function(storage=storage)
+        def func2(x: str) -> str:
+            return x.upper()
+        
+        # Generate entries
+        for i in range(5):
+            func1(i)
+            func2(f"test_{i}")
+        
+        # Wait for async saves
+        time.sleep(0.1)
+        
+        # Get all info
+        all_info = storage.get_all_log_files_info()
+        
+        assert "func1" in all_info
+        assert "func2" in all_info
+        assert all_info["func1"]["entry_count"] == 5
+        assert all_info["func2"]["entry_count"] == 5
+    
+    def test_nonexistent_file_rotation(self):
+        """Test rotation of nonexistent file"""
+        success = self.storage.force_rotate_log("nonexistent_func")
+        assert not success
+    
+    def test_entry_counter_tracking(self):
+        """Test that entry counters work correctly"""
+        monitor = get_monitor(
+            storage=LocalStorage(
+                log_dir=self.temp_dir,
+                max_file_size_mb=0.001,
+                rotation_batch_size=3
+            )
+        )
+        
+        @monitor.monitor
+        def test_func(data: str) -> str:
+            return f"Output: {data * 50}"
+        
+        # Generate entries to trigger counter tracking
+        for i in range(8):  # More entries to ensure counter is used
+            test_func(f"data_{i}")
+        
+        # Wait for processing
+        time.sleep(0.1)
+        
+        settings = monitor.storage.get_rotation_settings()
+        # Entry counter should exist for the function (might be 0 if reset after rotation)
+        assert "test_func" in settings["entry_counters"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__]) 


### PR DESCRIPTION
Defining limits on the size of the log file. Whenever the limits are exceeded, the oldest batch of logs would be deleted to make space for the new ones. 