### PR TITLE
Feat/database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ install-dev:
 
 # Run tests
 test:
-	python -m pytest tests/ -v --cov=imitator --cov-report=html --cov-report=term
+	python3 -m pytest tests/ -v --cov=imitator --cov-report=html --cov-report=term
 
 # Run linting
 lint:
@@ -93,3 +93,53 @@ dev: format lint test
 pre-commit:
 	pre-commit install
 	pre-commit run --all-files 
+
+# Database server management
+DB_CONTAINER_PREFIX = imitator-db
+
+# Start all database servers
+db-start:
+	@echo "Starting database servers..."
+	docker-compose -f docker-compose.db.yml up -d
+	@echo "Database servers started!"
+	@echo "PostgreSQL: localhost:5432 (user: postgres, password: password)"
+	@echo "MongoDB: localhost:27017"
+	@echo "Couchbase: localhost:8091 (user: admin, password: password)"
+
+# Stop all database servers
+db-stop:
+	@echo "Stopping database servers..."
+	docker-compose -f docker-compose.db.yml down
+	@echo "Database servers stopped!"
+
+# Test database connections
+db-test:
+	@echo "Testing database connections..."
+	python3 -c "\
+import psycopg2; \
+conn = psycopg2.connect('postgresql://postgres:password@localhost:5432/postgres'); \
+print('✅ PostgreSQL connection successful'); \
+conn.close()"
+	python3 -c "\
+from pymongo import MongoClient; \
+client = MongoClient('mongodb://localhost:27017/'); \
+print('✅ MongoDB connection successful'); \
+client.close()"
+	@echo "Note: Couchbase test requires manual verification at http://localhost:8091"
+
+# Run physics simulation test with database streaming
+db-physics-test:
+	@echo "Running physics simulation with database streaming..."
+	python examples/physics_simulation.py
+
+# Install database dependencies
+db-install:
+	@echo "Installing optional database dependencies..."
+	pip install psycopg2-binary pymongo couchbase
+	@echo "Database dependencies installed!"
+
+# Clean database data
+db-clean:
+	@echo "Cleaning database data..."
+	docker-compose -f docker-compose.db.yml down -v
+	@echo "Database data cleaned!" 

--- a/README.md
+++ b/README.md
@@ -343,3 +343,87 @@ We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.
 ## 📄 License
 
 Apache License 2.0 - see [LICENSE](LICENSE) file for details. 
+
+## Database Integration
+
+Imitator supports streaming function call logs to various databases. The database connectors use non-blocking background operations for optimal performance.
+
+### Setting Up Local Databases
+
+Use the provided `docker-compose.db.yml` file to start local database servers:
+
+```bash
+# Start all database servers
+make db-start
+
+# Stop all database servers  
+make db-stop
+
+# Test database connections
+make db-test
+
+# Clean database data
+make db-clean
+```
+
+This will start:
+- PostgreSQL on port 5432 (user: postgres, password: password)
+- MongoDB on port 27017  
+- Couchbase on port 8091 (user: admin, password: password)
+
+### Using Database Connectors
+
+```python
+from imitator import monitor_function, DatabaseStorage, PostgreSQLConnector, MongoDBConnector, CouchbaseConnector
+
+# PostgreSQL Example
+postgres_connector = PostgreSQLConnector(
+    connection_string="postgresql://postgres:password@localhost:5432/postgres",
+    table_name="function_calls"
+)
+postgres_storage = DatabaseStorage(postgres_connector)
+
+# MongoDB Example
+mongo_connector = MongoDBConnector(
+    connection_string="mongodb://localhost:27017/",
+    database_name="function_monitor", 
+    collection_name="calls"
+)
+mongo_storage = DatabaseStorage(mongo_connector)
+
+# Couchbase Example
+couchbase_connector = CouchbaseConnector(
+    connection_string="couchbase://localhost?username=admin&password=password",
+    bucket_name="function_bucket"
+)
+couchbase_storage = DatabaseStorage(couchbase_connector)
+
+# Monitor function with database storage
+@monitor_function(storage=postgres_storage)
+def my_function(data):
+    return process_data(data)
+```
+
+### Database Dependencies
+
+Install optional database dependencies as needed:
+
+```bash
+# Install all database dependencies
+make db-install
+
+# Or install individually
+pip install psycopg2-binary    # PostgreSQL
+pip install pymongo            # MongoDB  
+pip install couchbase          # Couchbase
+```
+
+### Connection Details
+
+The storage connection knows how to connect through the connection strings provided to each connector:
+
+- **PostgreSQL**: `postgresql://user:password@host:port/database`
+- **MongoDB**: `mongodb://host:port/`  
+- **Couchbase**: `couchbase://host1,host2?username=user&password=pass`
+
+All database operations are performed in background threads to avoid blocking your application. 

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -1,0 +1,64 @@
+services:
+  # PostgreSQL database
+  postgres:
+    image: postgres:15
+    container_name: imitator-postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  # MongoDB database
+  mongodb:
+    image: mongo:7
+    container_name: imitator-mongodb
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: admin
+      MONGO_INITDB_ROOT_PASSWORD: password
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  # Couchbase database
+  couchbase:
+    image: couchbase/server:community-7.2.0
+    container_name: imitator-couchbase
+    environment:
+      - COUCHBASE_ADMINISTRATOR_USERNAME=admin
+      - COUCHBASE_ADMINISTRATOR_PASSWORD=password
+      - COUCHBASE_BUCKET=function_bucket
+      - COUCHBASE_RAMSIZE=512
+    ports:
+      - "8091-8097:8091-8097"
+      - "9123:9123"
+      - "11207:11207"
+      - "11210:11210"
+      - "11280:11280"
+      - "18091-18097:18091-18097"
+    volumes:
+      - couchbase_data:/opt/couchbase/var
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8091/pools"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  postgres_data:
+  mongodb_data:
+  couchbase_data:

--- a/imitator/__init__.py
+++ b/imitator/__init__.py
@@ -1,25 +1,28 @@
 """
-LogAndLearn - A lightweight function monitoring and I/O logging framework
-
-A powerful yet simple framework for monitoring function I/O, tracking performance,
-and collecting data for machine learning, debugging, and analysis.
+Imitator - Function I/O monitoring and replay library
 """
 
-from .monitor import monitor_function, FunctionMonitor
-from .types import FunctionCall, IORecord, FunctionSignature
-from .storage import LocalStorage
+from .monitor import (
+    FunctionMonitor,
+    monitor_function,
+    LocalStorage,
+    DatabaseStorage,
+    PostgreSQLConnector,
+    MongoDBConnector,
+    CouchbaseConnector
+)
+from .types import FunctionCall, FunctionSignature, IORecord
 
 __version__ = "0.1.0"
-__author__ = "LogAndLearn Team"
-__email__ = "contact@logandlearn.dev"
-__license__ = "MIT"
-__description__ = "A lightweight Python framework for monitoring function I/O with automatic logging and type validation"
-
 __all__ = [
+    "FunctionMonitor",
     "monitor_function",
-    "FunctionMonitor", 
-    "FunctionCall",
-    "IORecord",
+    "FunctionCall", 
     "FunctionSignature",
-    "LocalStorage"
+    "IORecord",
+    "LocalStorage",
+    "DatabaseStorage",
+    "PostgreSQLConnector",
+    "MongoDBConnector",
+    "CouchbaseConnector"
 ] 

--- a/imitator/monitor.py
+++ b/imitator/monitor.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 
 from .types import FunctionCall, FunctionSignature, IORecord
-from .storage import LocalStorage
+from .storage import LocalStorage, DatabaseStorage, PostgreSQLConnector, MongoDBConnector, CouchbaseConnector
 
 
 class FunctionMonitor:
@@ -423,3 +423,14 @@ def get_monitor(storage: Optional[LocalStorage] = None,
                 max_calls_per_minute: Optional[int] = None) -> FunctionMonitor:
     """Get a function monitor instance"""
     return FunctionMonitor(storage, sampling_rate, max_calls_per_minute) 
+
+# Export all public classes
+__all__ = [
+    'FunctionMonitor',
+    'monitor_function', 
+    'LocalStorage',
+    'DatabaseStorage',
+    'PostgreSQLConnector',
+    'MongoDBConnector',
+    'CouchbaseConnector'
+] 

--- a/imitator/storage.py
+++ b/imitator/storage.py
@@ -5,12 +5,48 @@ Local storage backend for function I/O logs
 import json
 import os
 from pathlib import Path
-from typing import List, Optional, Dict
-from datetime import datetime
+from typing import List, Optional, Dict, Protocol
+from datetime import datetime, timedelta
 from collections import defaultdict
 import threading
+import concurrent.futures
+from abc import ABC, abstractmethod
+from .types import FunctionCall, FunctionSignature, IORecord
+from psycopg2 import sql
 
-from .types import FunctionCall
+from .types import FunctionCall, TimeInterval, FunctionSignature, IORecord
+
+
+def _default_time_interval() -> TimeInterval:
+    """Create a default TimeInterval starting 1 hour ago"""
+    now = datetime.now()
+    start_time = now - timedelta(hours=1)
+    # Don't set end_time to allow for calls that happen after this interval is created
+    return TimeInterval(start_time=start_time, end_time=None)
+
+
+class DatabaseConnector(Protocol):
+    """Protocol for database connectors"""
+    
+    def connect(self) -> None:
+        """Establish connection to the database"""
+        ...
+    
+    def disconnect(self) -> None:
+        """Close database connection"""
+        ...
+    
+    def save_calls(self, calls: List[FunctionCall], function_name: str) -> None:
+        """Save function calls to the database in batch"""
+        ...
+    
+    def load_calls(self, function_name: str, time_interval: TimeInterval) -> List[FunctionCall]:
+        """Load function calls from the database"""
+        ...
+    
+    def get_all_functions(self) -> List[str]:
+        """Get list of all monitored functions in the database"""
+        ...
 
 
 class LocalStorage:
@@ -88,36 +124,66 @@ class LocalStorage:
         self.flush()
         # No background thread to stop in this simple implementation
 
-    def load_calls(self, function_name: str, date: Optional[str] = None) -> List[FunctionCall]:
+    def _get_dates_to_scan(self, time_interval: TimeInterval) -> set[str]:
+        start, end = time_interval.normalized_bounds()
+        # Generate all dates from start to end (inclusive)
+        dates_to_scan = set()
+        
+        if end is None:
+            # If no end date, just add the start date
+            dates_to_scan.add(start.strftime("%Y%m%d"))
+        else:
+            # Use for loop with date range
+            num_days = (end - start).days + 1
+            for day_offset in range(num_days):
+                current_date = start + timedelta(days=day_offset)
+                dates_to_scan.add(current_date.strftime("%Y%m%d"))
+        
+        return dates_to_scan
+
+    def _within_time_interval(self, call_id_timestamp: float, start_timestamp: float, end_timestamp: float) -> bool:
+        """Check if a call_id timestamp is within a time interval"""
+        return call_id_timestamp >= start_timestamp and call_id_timestamp <= end_timestamp
+
+    def load_calls(self, function_name: str, time_interval: TimeInterval = None) -> List[FunctionCall]:
         """
         Load function calls from storage
         
         Args:
             function_name: Name of the function
-            date: Date in YYYYMMDD format, if None uses today
         """
-        if date is None:
-            date = datetime.now().strftime("%Y%m%d")
+        if time_interval is None:
+            time_interval = _default_time_interval()
+   
+        start, end = time_interval.normalized_bounds()        
         
-        log_file = self.log_dir / f"{function_name}_{date}.{self.format}"
-        
-        if not log_file.exists():
-            return []
-        
+        # Convert time_interval to timestamps for call_id filtering if provided
+        start_timestamp = start.timestamp()
+        end_timestamp = end.timestamp() if end is not None else datetime.now().timestamp()
+
         calls = []
         
-        if self.format == "jsonl":
-            with open(log_file, "r", encoding="utf-8") as f:
-                for line in f:
-                    if line.strip():
-                        call_data = json.loads(line)
-                        calls.append(FunctionCall.model_validate(call_data))
-        else:
-            with open(log_file, "r", encoding="utf-8") as f:
-                call_data_list = json.load(f)
-                for call_data in call_data_list:
-                    calls.append(FunctionCall.model_validate(call_data))
+        dates_to_scan = self._get_dates_to_scan(time_interval)
+        for date_str in sorted(dates_to_scan):
+            log_file = self.log_dir / f"{function_name}_{date_str}.{self.format}"
+            if not log_file.exists():
+                continue
         
+            if self.format == "jsonl":
+                with open(log_file, "r", encoding="utf-8") as f:
+                    for line in f:
+                        if line.strip():
+                            call_data = json.loads(line)
+                            call_id_timestamp = float(call_data.get("call_id", "0"))
+                            if self._within_time_interval(call_id_timestamp, start_timestamp, end_timestamp):
+                                calls.append(FunctionCall.model_validate(call_data))
+            else:
+                with open(log_file, "r", encoding="utf-8") as f:
+                    call_data_list = json.load(f)
+                    for call_data in call_data_list:
+                        call_id_timestamp = float(call_data.get("call_id", "0"))
+                        if self._within_time_interval(call_id_timestamp, start_timestamp, end_timestamp):
+                            calls.append(FunctionCall.model_validate(call_data))
         return calls
     
     def get_all_functions(self) -> List[str]:
@@ -134,3 +200,552 @@ class LocalStorage:
                 function_name = match.group(1)
                 functions.add(function_name)
         return list(functions) 
+
+
+class DatabaseStorage(LocalStorage):
+    """Database storage backend that uses database connectors with non-blocking operations"""
+    
+    def __init__(self, connector: DatabaseConnector, buffer_size=100, flush_interval=None):
+        """
+        Initialize database storage
+        
+        Args:
+            connector: Database connector instance
+            buffer_size: Number of calls to buffer before flushing
+            flush_interval: Interval in seconds for automatic flushing (None for manual)
+        """
+        super().__init__(buffer_size=buffer_size, flush_interval=flush_interval)
+        self.connector = connector
+        self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        self._connected = False
+        
+    def _ensure_connected(self):
+        """Ensure database connection is established"""
+        if not self._connected:
+            self.connector.connect()
+            self._connected = True
+    
+    def _flush_function(self, function_name):
+        """Write all buffered calls for a function to database in background thread"""
+        calls_to_write = self._buffer[function_name]
+        self._buffer[function_name] = []  # Clear buffer immediately
+        
+        if calls_to_write:
+            # Submit database operation to background thread
+            self._executor.submit(self._save_calls_async, calls_to_write, function_name)
+    
+    def _save_calls_async(self, calls: List[FunctionCall], function_name: str):
+        """Save calls to database in background thread (non-blocking)"""
+        try:
+            self._ensure_connected()
+            self.connector.save_calls(calls, function_name)
+        except Exception as e:
+            # Log error but don't crash the application
+            import logging
+            logging.error(f"Failed to save calls to database: {e}")
+            # Optionally, you could implement retry logic here
+    
+    def flush(self):
+        """Flush all buffers to database"""
+        with self._lock:
+            for function_name in list(self._buffer.keys()):
+                if self._buffer[function_name]:
+                    self._flush_function(function_name)
+    
+    def close(self):
+        """Flush buffers and close database connection"""
+        self.flush()
+        self._executor.shutdown(wait=True)  # Wait for all background operations
+        if self._connected:
+            self.connector.disconnect()
+            self._connected = False
+    
+    def load_calls(self, function_name: str, time_interval: TimeInterval = None) -> List[FunctionCall]:
+        """Load function calls from database"""
+        if time_interval is None:
+            time_interval = _default_time_interval()
+        self._ensure_connected()
+        return self.connector.load_calls(function_name, time_interval=time_interval)
+    
+    def get_all_functions(self) -> List[str]:
+        """Get list of all monitored functions from database"""
+        self._ensure_connected()
+        return self.connector.get_all_functions() 
+
+# Database Connector Implementations
+
+class PostgreSQLConnector:
+    """PostgreSQL database connector for function call logs"""
+    
+    def __init__(self, connection_string: str, table_name: str = "function_calls"):
+        """
+        Initialize PostgreSQL connector
+        
+        Args:
+            connection_string: PostgreSQL connection string
+            table_name: Name of the table to store function calls
+        """
+        self.connection_string = connection_string
+        self.table_name = table_name
+        self._connection = None
+    
+    def connect(self) -> None:
+        """Establish connection to PostgreSQL database"""
+        try:
+            import psycopg2
+            self._connection = psycopg2.connect(self.connection_string)
+            self._ensure_table_exists()
+        except ImportError:
+            raise ImportError("psycopg2 is required for PostgreSQL support. Install it with 'pip install psycopg2-binary'")
+    
+    def _ensure_table_exists(self):
+        """Ensure the function calls table exists"""
+        
+        create_table_query = sql.SQL("""
+            CREATE TABLE IF NOT EXISTS {table} (
+                id SERIAL PRIMARY KEY,
+                call_id VARCHAR(255) UNIQUE,
+                function_name VARCHAR(255) NOT NULL,
+                inputs JSONB NOT NULL,
+                output JSONB,
+                timestamp TIMESTAMP NOT NULL,
+                execution_time_ms FLOAT,
+                input_modifications JSONB,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """).format(table=sql.Identifier(self.table_name))
+        
+        with self._connection.cursor() as cursor:
+            cursor.execute(create_table_query)
+            self._connection.commit()
+    
+    def disconnect(self) -> None:
+        """Close PostgreSQL connection"""
+        if self._connection:
+            self._connection.close()
+            self._connection = None
+    
+    def save_calls(self, calls: List[FunctionCall], function_name: str) -> None:
+        """Save function calls to PostgreSQL in batch"""
+        if self._connection is None:
+            raise ConnectionError("Database connection not established")
+                
+        insert_query = sql.SQL("""
+            INSERT INTO {table} (call_id, function_name, inputs, output, timestamp, execution_time_ms, input_modifications)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (call_id) DO NOTHING
+        """).format(table=sql.Identifier(self.table_name))
+        
+        data = []
+        for call in calls:
+            data.append((
+                call.call_id,
+                function_name,
+                json.dumps(call.io_record.inputs, default=str),
+                json.dumps(call.io_record.output, default=str) if call.io_record.output is not None else None,
+                call.io_record.timestamp,
+                call.io_record.execution_time_ms,
+                json.dumps(call.io_record.input_modifications, default=str) if call.io_record.input_modifications else None
+            ))
+        
+        with self._connection.cursor() as cursor:
+            cursor.executemany(insert_query, data)
+            self._connection.commit()
+    
+    def load_calls(self, function_name: str, time_interval: TimeInterval = None) -> List[FunctionCall]:
+        """Load function calls from PostgreSQL"""
+        if time_interval is None:
+            time_interval = _default_time_interval()
+            
+        if self._connection is None:
+            raise ConnectionError("Database connection not established")
+                
+        # Get normalized time bounds
+        start, end = time_interval.normalized_bounds()
+        
+        # Build query with time filtering
+        if end is not None:
+            query = sql.SQL("""
+                SELECT call_id, inputs, output, timestamp, execution_time_ms, input_modifications
+                FROM {table}
+                WHERE function_name = %s AND timestamp >= %s AND timestamp <= %s
+                ORDER BY timestamp
+            """).format(table=sql.Identifier(self.table_name))
+            params = [function_name, start, end]
+        else:
+            query = sql.SQL("""
+                SELECT call_id, inputs, output, timestamp, execution_time_ms, input_modifications
+                FROM {table}
+                WHERE function_name = %s AND timestamp >= %s
+                ORDER BY timestamp
+            """).format(table=sql.Identifier(self.table_name))
+            params = [function_name, start]
+        
+        with self._connection.cursor() as cursor:
+            cursor.execute(query, params)
+            results = cursor.fetchall()
+        
+        calls = []
+        for row in results:
+            call_id, inputs_json, output_json, timestamp, execution_time_ms, input_modifications_json = row
+            
+            # Create FunctionSignature (simplified for loading)
+            function_signature = FunctionSignature(
+                name=function_name,
+                parameters={},
+                return_type=None
+            )
+            
+            # Create IORecord
+            # Note: PostgreSQL JSONB columns are automatically deserialized by psycopg2
+            io_record = IORecord(
+                inputs=inputs_json,
+                output=output_json,
+                timestamp=timestamp,
+                execution_time_ms=execution_time_ms,
+                input_modifications=input_modifications_json
+            )
+            
+            calls.append(FunctionCall(
+                function_signature=function_signature,
+                io_record=io_record,
+                call_id=call_id
+            ))
+        
+        return calls
+    
+    def get_all_functions(self) -> List[str]:
+        """Get list of all monitored functions from PostgreSQL"""
+        if self._connection is None:
+            raise ConnectionError("Database connection not established")
+                
+        query = sql.SQL("""
+            SELECT DISTINCT function_name
+            FROM {table}
+            ORDER BY function_name
+        """).format(table=sql.Identifier(self.table_name))
+        
+        with self._connection.cursor() as cursor:
+            cursor.execute(query)
+            results = cursor.fetchall()
+        
+        return [row[0] for row in results] 
+
+class MongoDBConnector:
+    """MongoDB database connector for function call logs"""
+    
+    def __init__(self, connection_string: str, database_name: str = "function_monitor", collection_name: str = "function_calls"):
+        """
+        Initialize MongoDB connector
+        
+        Args:
+            connection_string: MongoDB connection string
+            database_name: Name of the database
+            collection_name: Name of the collection to store function calls
+        """
+        self.connection_string = connection_string
+        self.database_name = database_name
+        self.collection_name = collection_name
+        self._client = None
+        self._database = None
+        self._collection = None
+    
+    def connect(self) -> None:
+        """Establish connection to MongoDB database"""
+        try:
+            from pymongo import MongoClient
+            from pymongo.errors import ConnectionFailure
+            
+            self._client = MongoClient(self.connection_string)
+            # Verify connection
+            self._client.admin.command('ping')
+            self._database = self._client[self.database_name]
+            self._collection = self._database[self.collection_name]
+            
+            # Create indexes for better query performance
+            self._collection.create_index([("function_name", 1), ("timestamp", -1)])
+            self._collection.create_index([("call_id", 1)], unique=True)
+            
+        except ImportError:
+            raise ImportError("pymongo is required for MongoDB support. Install it with 'pip install pymongo'")
+        except ConnectionFailure:
+            raise ConnectionError("Failed to connect to MongoDB")
+    
+    def disconnect(self) -> None:
+        """Close MongoDB connection"""
+        if self._client:
+            self._client.close()
+            self._client = None
+            self._database = None
+            self._collection = None
+    
+    def save_calls(self, calls: List[FunctionCall], function_name: str) -> None:
+        """Save function calls to MongoDB in batch"""
+        if self._collection is None:
+            raise ConnectionError("Database connection not established")
+        
+        documents = []
+        for call in calls:
+            document = {
+                "call_id": call.call_id,
+                "function_name": function_name,
+                "inputs": call.io_record.inputs,
+                "output": call.io_record.output,
+                "timestamp": call.io_record.timestamp,
+                "execution_time_ms": call.io_record.execution_time_ms,
+                "input_modifications": call.io_record.input_modifications,
+                "created_at": datetime.now()
+            }
+            documents.append(document)
+        
+        print("documents", documents)
+        
+        if documents:
+            try:
+                self._collection.insert_many(documents, ordered=False)
+            except:
+                # If bulk insert fails, try individual inserts
+                for doc in documents:
+                    try:
+                        self._collection.insert_one(doc)
+                    except:
+                        # Skip duplicates and continue
+                        continue
+    
+    def load_calls(self, function_name: str, time_interval: TimeInterval = None) -> List[FunctionCall]:
+        """Load function calls from MongoDB"""
+        if time_interval is None:
+            time_interval = _default_time_interval()
+            
+        if self._collection is None:
+            raise ConnectionError("Database connection not established")
+        
+        query = {"function_name": function_name}
+        
+        start, end = time_interval.normalized_bounds()
+        if end is None:
+            query["timestamp"] = {"$gte": start}
+        else:
+            query["timestamp"] = {"$gte": start, "$lte": end}
+        
+        
+        cursor = self._collection.find(query).sort("timestamp", 1)
+        
+        calls = []
+        for doc in cursor:
+            # Create FunctionSignature (simplified for loading)
+            function_signature = FunctionSignature(
+                name=function_name,
+                parameters={},
+                return_type=None
+            )
+            
+            # Create IORecord
+            io_record = IORecord(
+                inputs=doc["inputs"],
+                output=doc["output"],
+                timestamp=doc["timestamp"],
+                execution_time_ms=doc.get("execution_time_ms"),
+                input_modifications=doc.get("input_modifications")
+            )
+            
+            calls.append(FunctionCall(
+                function_signature=function_signature,
+                io_record=io_record,
+                call_id=doc["call_id"]
+            ))
+        
+        return calls
+    
+    def get_all_functions(self) -> List[str]:
+        """Get list of all monitored functions from MongoDB"""
+        if self._collection is None:
+            raise ConnectionError("Database connection not established")
+        
+        return self._collection.distinct("function_name") 
+
+class CouchbaseConnector:
+    """Couchbase database connector for function call logs"""
+    
+    def __init__(self, connection_string: str, bucket_name: str = "function_monitor", 
+                 scope_name: str = "_default", collection_name: str = "function_calls"):
+        """
+        Initialize Couchbase connector
+        
+        Args:
+            connection_string: Couchbase connection string
+            bucket_name: Name of the bucket
+            scope_name: Name of the scope
+            collection_name: Name of the collection to store function calls
+        """
+        self.connection_string = connection_string
+        self.bucket_name = bucket_name
+        self.scope_name = scope_name
+        self.collection_name = collection_name
+        self._cluster = None
+        self._bucket = None
+        self._collection = None
+    
+    def connect(self) -> None:
+        """Establish connection to Couchbase database"""
+        try:
+            from couchbase.cluster import Cluster
+            from couchbase.options import ClusterOptions
+            from couchbase.auth import PasswordAuthenticator
+            from couchbase.exceptions import CouchbaseException
+            
+            # Parse connection string (format: couchbase://host1,host2?username=user&password=pass)
+            import urllib.parse
+            parsed = urllib.parse.urlparse(self.connection_string)
+            hosts = parsed.netloc.split(',')
+            
+            # Extract credentials from query parameters
+            query_params = urllib.parse.parse_qs(parsed.query)
+            username = query_params.get('username', [''])[0]
+            password = query_params.get('password', [''])[0]
+            
+            if not username or not password:
+                raise ValueError("Username and password must be provided in connection string")
+            
+            auth = PasswordAuthenticator(username, password)
+            cluster_options = ClusterOptions(auth)
+            
+            self._cluster = Cluster(f"couchbase://{','.join(hosts)}", cluster_options)
+            
+            # Wait for cluster to be ready
+            from datetime import timedelta
+            self._cluster.wait_until_ready(timedelta(seconds=5))
+            
+            self._bucket = self._cluster.bucket(self.bucket_name)
+            self._collection = self._bucket.scope(self.scope_name).collection(self.collection_name)
+            
+        except ImportError:
+            raise ImportError("couchbase is required for Couchbase support. Install it with 'pip install couchbase'")
+        except CouchbaseException as e:
+            raise ConnectionError(f"Failed to connect to Couchbase: {e}")
+    
+    def disconnect(self) -> None:
+        """Close Couchbase connection"""
+        if self._cluster:
+            self._cluster.close()
+            self._cluster = None
+            self._bucket = None
+            self._collection = None
+    
+    def save_calls(self, calls: List[FunctionCall], function_name: str) -> None:
+        """Save function calls to Couchbase in batch"""
+        if self._collection is None:
+            raise ConnectionError("Database connection not established")
+        
+        from couchbase.exceptions import DocumentExistsException
+        
+        for call in calls:
+            document_id = f"function_call::{call.call_id}"
+            document = {
+                "call_id": call.call_id,
+                "function_name": function_name,
+                "inputs": call.io_record.inputs,
+                "output": call.io_record.output,
+                "timestamp": call.io_record.timestamp.isoformat(),
+                "execution_time_ms": call.io_record.execution_time_ms,
+                "input_modifications": call.io_record.input_modifications,
+                "created_at": datetime.now().isoformat()
+            }
+            
+            try:
+                self._collection.insert(document_id, document)
+            except DocumentExistsException:
+                # Skip duplicates
+                continue
+            except Exception as e:
+                # Log other errors but continue
+                import logging
+                logging.error(f"Failed to save call {call.call_id} to Couchbase: {e}")
+    
+    def load_calls(self, function_name: str, time_interval: TimeInterval = None) -> List[FunctionCall]:
+        """Load function calls from Couchbase"""
+        if time_interval is None:
+            time_interval = _default_time_interval()
+            
+        if self._collection is None:
+            raise ConnectionError("Database connection not established")
+        
+        from datetime import datetime
+        
+        # Build N1QL query
+        query = f"""
+            SELECT META().id, call_id, inputs, output, timestamp, execution_time_ms, input_modifications
+            FROM `{self.bucket_name}`.`{self.scope_name}`.`{self.collection_name}`
+            WHERE function_name = $function_name
+        """
+        
+        params = {"function_name": function_name}
+        
+        if time_interval is not None:
+            start, end = time_interval.normalized_bounds()
+            if end is None:
+                query += " AND timestamp >= $start_time"
+                params.update({"start_time": start.isoformat()})
+            else:
+                query += " AND timestamp >= $start_time AND timestamp <= $end_time"
+                params.update({
+                    "start_time": start.isoformat(),
+                    "end_time": end.isoformat()
+                })
+        
+        
+        query += " ORDER BY timestamp"
+        
+        try:
+            result = self._cluster.query(query, params)
+            rows = result.rows()
+        except Exception as e:
+            raise ConnectionError(f"Failed to query Couchbase: {e}")
+        
+        calls = []
+        for row in rows:
+            document_id, call_id, inputs, output, timestamp_str, execution_time_ms, input_modifications = row
+            
+            # Create FunctionSignature (simplified for loading)
+            function_signature = FunctionSignature(
+                name=function_name,
+                parameters={},
+                return_type=None
+            )
+            
+            # Parse timestamp
+            timestamp = datetime.fromisoformat(timestamp_str)
+            
+            # Create IORecord
+            io_record = IORecord(
+                inputs=inputs,
+                output=output,
+                timestamp=timestamp,
+                execution_time_ms=execution_time_ms,
+                input_modifications=input_modifications
+            )
+            
+            calls.append(FunctionCall(
+                function_signature=function_signature,
+                io_record=io_record,
+                call_id=call_id
+            ))
+        
+        return calls
+    
+    def get_all_functions(self) -> List[str]:
+        """Get list of all monitored functions from Couchbase"""
+        if self._collection is None:
+            raise ConnectionError("Database connection not established")
+        
+        query = f"""
+            SELECT DISTINCT function_name
+            FROM `{self.bucket_name}`.`{self.scope_name}`.`{self.collection_name}`
+            ORDER BY function_name
+        """
+        
+        try:
+            result = self._cluster.query(query)
+            return [row["function_name"] for row in result.rows()]
+        except Exception as e:
+            raise ConnectionError(f"Failed to query Couchbase: {e}") 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,15 @@
+# Core dependencies
 pydantic>=2.0.0
 pytest>=7.0.0
-pytest-asyncio>=0.20.0 
+pytest-asyncio>=0.20.0
+
+# Optional database dependencies (install as needed)
+# For PostgreSQL support:
+# psycopg2-binary>=2.9.0
+
+# For MongoDB support:  
+# pymongo>=4.0.0
+
+# For Couchbase support:
+# couchbase>=4.0.0
+``` 

--- a/tests/test_couchbase_connector.py
+++ b/tests/test_couchbase_connector.py
@@ -1,0 +1,158 @@
+"""
+Test Couchbase database connector with physics simulation
+"""
+
+import pytest
+import numpy as np
+from imitator import monitor_function, DatabaseStorage, CouchbaseConnector
+from imitator.types import FunctionCall, FunctionSignature
+
+
+class TestCouchbaseConnector:
+    """Test Couchbase database connector with physics simulation"""
+    
+    @pytest.fixture
+    def couchbase_connector(self):
+        """Fixture to provide Couchbase connector for testing"""
+        # Use test database connection
+        connector = CouchbaseConnector(
+            connection_string="couchbase://localhost?username=admin&password=password",
+            bucket_name="function_bucket",
+            collection_name="test_calls"
+        )
+        return connector
+    
+    @pytest.fixture
+    def couchbase_storage(self, couchbase_connector):
+        """Fixture to provide DatabaseStorage with Couchbase connector"""
+        return DatabaseStorage(couchbase_connector, buffer_size=5)
+    
+    def test_couchbase_connection(self, couchbase_connector):
+        """Test Couchbase connection establishment"""
+        # Note: Couchbase connection test might be skipped if server not available
+        try:
+            couchbase_connector.connect()
+            assert couchbase_connector._cluster is not None
+            couchbase_connector.disconnect()
+        except Exception as e:
+            pytest.skip(f"Couchbase server not available: {e}")
+    
+    def test_physics_simulation_couchbase(self, couchbase_storage, clean_logs):
+        """Test physics simulation with Couchbase database streaming"""
+        
+        # Astrophysics simulation functions
+        @monitor_function(storage=couchbase_storage)
+        def calculate_schwarzschild_radius(mass: float) -> float:
+            """Calculate Schwarzschild radius: R_s = 2GM/c^2"""
+            G = 6.67430e-11  # Gravitational constant
+            c = 299792458.0   # Speed of light
+            return (2 * G * mass) / (c ** 2)
+        
+        @monitor_function(storage=couchbase_storage)
+        def calculate_hubble_flow_distance(redshift: float, hubble_constant: float = 70.0) -> float:
+            """Calculate Hubble flow distance: d = c * z / H0"""
+            c = 299792458.0  # Speed of light in m/s
+            H0 = hubble_constant * 1000  # Convert to m/s/MPc
+            return (c * redshift) / H0
+        
+        @monitor_function(storage=couchbase_storage)
+        def simulate_black_hole(
+            mass: float,
+            spin: float = 0.0,
+            charge: float = 0.0
+        ) -> dict:
+            """Simulate black hole properties"""
+            G = 6.67430e-11
+            c = 299792458.0
+            
+            # Schwarzschild radius
+            schwarzschild_radius = (2 * G * mass) / (c ** 2)
+            
+            # Event horizon (for non-rotating, uncharged black hole)
+            event_horizon = schwarzschild_radius
+            
+            # Hawking temperature
+            hawking_temperature = (6.626e-34 * (c ** 3)) / (8 * np.pi * G * mass * 1.38e-23)
+            
+            # Hawking radiation lifetime
+            if mass > 0:
+                lifetime = (5120 * np.pi * (G ** 2) * (mass ** 3)) / (6.626e-34 * (c ** 4))
+            else:
+                lifetime = float('inf')
+            
+            return {
+                "mass": mass,
+                "spin": spin,
+                "charge": charge,
+                "schwarzschild_radius": schwarzschild_radius,
+                "event_horizon": event_horizon,
+                "hawking_temperature": hawking_temperature,
+                "lifetime_years": lifetime / (365.25 * 24 * 3600) if lifetime != float('inf') else float('inf')
+            }
+        
+        # Run astrophysics simulations
+        results = []
+        
+        # Test Schwarzschild radius calculations
+        for mass in [1.989e30, 5.972e24, 7.348e22]:  # Sun, Earth, Moon masses
+            radius = calculate_schwarzschild_radius(mass)
+            results.append(radius)
+            G = 6.67430e-11
+            c = 299792458.0
+            expected = (2 * G * mass) / (c ** 2)
+            assert abs(radius - expected) < 1e-20
+        
+        # Test Hubble flow distance calculations
+        for redshift in [0.1, 0.5, 2.0]:
+            distance = calculate_hubble_flow_distance(redshift)
+            results.append(distance)
+            c = 299792458.0
+            H0 = 70.0 * 1000  # m/s/MPc
+            expected = (c * redshift) / H0
+            assert abs(distance - expected) < 1e-10
+        
+        # Test black hole simulations
+        black_hole_results = []
+        test_masses = [1.989e30, 1.989e31, 1.989e32]  # Solar masses
+        
+        for mass in test_masses:
+            black_hole = simulate_black_hole(mass)
+            black_hole_results.append(black_hole)
+            
+            # Verify black hole properties
+            assert black_hole["schwarzschild_radius"] > 0
+            assert black_hole["event_horizon"] > 0
+            assert black_hole["hawking_temperature"] >= 0
+        
+        # Flush buffers to ensure all calls are saved
+        couchbase_storage.flush()
+        couchbase_storage.close()
+        
+        # Verify calls were logged to Couchbase
+        connector = couchbase_storage.connector
+        try:
+            connector.connect()
+            
+            # Check Schwarzschild calls
+            schwarzschild_calls = connector.load_calls("calculate_schwarzschild_radius")
+            assert len(schwarzschild_calls) == 3, f"Expected 3 Schwarzschild calls, got {len(schwarzschild_calls)}"
+            
+            # Check Hubble calls
+            hubble_calls = connector.load_calls("calculate_hubble_flow_distance")
+            assert len(hubble_calls) == 3, f"Expected 3 Hubble calls, got {极en(hubble_calls)}"
+            
+            # Check black hole calls
+            black_hole_calls = connector.load_calls("simulate_black_hole")
+            assert len(black_hole_calls) == 3, f"Expected 3 black hole calls, got {len(black_hole_calls)}"
+            
+            # Verify function names
+            functions = connector.get_all_functions()
+            expected_functions = {"calculate_schwarzschild_radius", "calculate_hubble极low_distance", "simulate_black_hole"}
+            assert expected_functions.issubset(functions)
+            
+            connector.disconnect()
+            
+        except Exception as e:
+            pytest.skip(f"Couchbase server not available for verification: {e}")
+        
+        return results, black_hole_results

--- a/tests/test_mongodb_connector.py
+++ b/tests/test_mongodb_connector.py
@@ -1,0 +1,118 @@
+"""
+Test MongoDB database connector with physics simulation
+"""
+
+import pytest
+import numpy as np
+from imitator import monitor_function, DatabaseStorage, MongoDBConnector
+from imitator.types import FunctionCall, FunctionSignature
+from datetime import datetime
+from imitator.types import TimeInterval
+
+
+class TestMongoDBConnector:
+    """Test MongoDB database connector with physics simulation"""
+    
+    @pytest.fixture
+    def mongodb_connector(self):
+        """Fixture to provide MongoDB connector for testing"""
+        # Use test database connection
+        connector = MongoDBConnector(
+            connection_string="mongodb://admin:password@localhost:27017/",
+            database_name="test_function_monitor",
+            collection_name="test_calls"
+        )
+        return connector
+    
+    @pytest.fixture
+    def mongodb_storage(self, mongodb_connector):
+        """Fixture to provide DatabaseStorage with MongoDB connector"""
+        return DatabaseStorage(mongodb_connector, buffer_size=5)
+    
+    def test_mongodb_connection(self, mongodb_connector):
+        """Test MongoDB connection establishment"""
+        mongodb_connector.connect()
+        assert mongodb_connector._client is not None
+        assert mongodb_connector._collection is not None
+        mongodb_connector.disconnect()
+    
+    def test_physics_simulation_mongodb(self, mongodb_storage, clean_logs):
+        """Test physics simulation with MongoDB database streaming"""
+
+        start_time = datetime.now()
+        
+        # Quantum mechanics simulation functions
+        @monitor_function(storage=mongodb_storage)
+        def calculate_traffic_flow(density: float, speed: float) -> float:
+            """Calculate traffic flow: Flow = Density * Speed"""
+            return density * speed
+        
+        @monitor_function(storage=mongodb_storage)
+        def calculate_traffic_density(num_vehicles: int, road_length_km: float) -> float:
+            """Calculate traffic density: Density = Number of Vehicles / Road Length"""
+            if road_length_km == 0:
+                raise ValueError("Road length cannot be zero.")
+            return num_vehicles / road_length_km
+        
+        @monitor_function(storage=mongodb_storage)
+        def calculate_travel_time(distance_km: float, speed_kmph: float) -> float:
+            """Calculate travel time: Time = Distance / Speed"""
+            if speed_kmph <= 0:
+                raise ValueError("Speed must be greater than zero.")
+            return distance_km / speed_kmph
+
+        # Run traffic simulation
+        results = []
+        
+        # Test traffic flow calculations
+        for density, speed in [(20.0, 60.0), (30.0, 40.0), (10.0, 80.0)]:
+            flow = calculate_traffic_flow(density, speed)
+            results.append(flow)
+            expected = density * speed
+            assert abs(flow - expected) < 1e-9
+        
+        # Test traffic density calculations
+        for num_vehicles, road_length in [(100, 5.0), (150, 10.0), (50, 2.5)]:
+            density = calculate_traffic_density(num_vehicles, road_length)
+            results.append(density)
+            expected = num_vehicles / road_length
+            assert abs(density - expected) < 1e-9
+        
+        # Test travel time calculations
+        travel_time_results = []
+        for distance, speed in [(100.0, 80.0), (50.0, 60.0), (200.0, 100.0)]:
+            time = calculate_travel_time(distance, speed)
+            travel_time_results.append(time)
+            
+            assert time > 0
+        
+        # Flush buffers to ensure all calls are saved
+        mongodb_storage.flush()
+        mongodb_storage.close()
+        
+        # Verify calls were logged to MongoDB
+        connector = mongodb_storage.connector
+        connector.connect()
+        
+        time_interval = TimeInterval(start_time=start_time)
+
+        # Check traffic flow calls
+        flow_calls = connector.load_calls("calculate_traffic_flow", time_interval=time_interval)
+        assert len(flow_calls) == 3, f"Expected 3 traffic flow calls, got {len(flow_calls)}"
+        
+        # Check traffic density calls
+        density_calls = connector.load_calls("calculate_traffic_density", time_interval=time_interval)
+        assert len(density_calls) == 3, f"Expected 3 traffic density calls, got {len(density_calls)}"
+        
+        # Check travel time calls
+        travel_time_calls = connector.load_calls("calculate_travel_time", time_interval=time_interval)
+        assert len(travel_time_calls) == 3, f"Expected 3 travel time calls, got {len(travel_time_calls)}"
+        
+        # Verify function names
+        functions = connector.get_all_functions()
+        expected_functions = {"calculate_traffic_flow", "calculate_traffic_density", "calculate_travel_time"}
+        assert expected_functions.issubset(functions)
+        
+        connector.disconnect()
+        
+        return results, travel_time_results

--- a/tests/test_postgres_connector.py
+++ b/tests/test_postgres_connector.py
@@ -1,0 +1,138 @@
+"""
+Test PostgreSQL database connector with physics simulation
+"""
+
+import pytest
+import numpy as np
+from imitator import monitor_function, DatabaseStorage, PostgreSQLConnector
+from imitator.types import FunctionCall, FunctionSignature
+from datetime import datetime
+from imitator.types import TimeInterval
+
+class TestPostgreSQLConnector:
+    """Test PostgreSQL database connector with physics simulation"""
+    
+    @pytest.fixture
+    def postgres_connector(self):
+        """Fixture to provide PostgreSQL connector for testing"""
+        # Use test database connection
+        connector = PostgreSQLConnector(
+            connection_string="postgresql://postgres:password@localhost:5432/postgres",
+            table_name="test_function_calls"
+        )
+        return connector
+    
+    @pytest.fixture
+    def postgres_storage(self, postgres_connector):
+        """Fixture to provide DatabaseStorage with PostgreSQL connector"""
+        return DatabaseStorage(postgres_connector, buffer_size=5)
+    
+    def test_postgres_connection(self, postgres_connector):
+        """Test PostgreSQL connection establishment"""
+        postgres_connector.connect()
+        assert postgres_connector._connection is not None
+        postgres_connector.disconnect()
+    
+    def test_physics_simulation_postgres(self, postgres_storage, clean_logs):
+        """Test physics simulation with PostgreSQL database streaming"""
+        
+        start_time = datetime.now()
+
+        # Simple physics simulation functions
+        @monitor_function(storage=postgres_storage)
+        def calculate_kinetic_energy(mass: float, velocity: float) -> float:
+            """Calculate kinetic energy: KE = 0.5 * mass * velocity^2"""
+            return 0.5 * mass * (velocity ** 2)
+        
+        @monitor_function(storage=postgres_storage) 
+        def calculate_pendulum_period(length: float, gravity: float = 9.81) -> float:
+            """Calculate pendulum period: T = 2π * sqrt(L/g)"""
+            return 2 * np.pi * np.sqrt(length / gravity)
+        
+        @monitor_function(storage=postgres_storage)
+        def simulate_projectile_motion(initial_velocity: float, angle_degrees: float, 
+                                     gravity: float = 9.81) -> dict:
+            """Simulate projectile motion and return trajectory data"""
+            angle_rad = np.radians(angle_degrees)
+            
+            # Calculate components
+            vx = initial_velocity * np.cos(angle_rad)
+            vy = initial_velocity * np.sin(angle_rad)
+            
+            # Time of flight
+            time_of_flight = (2 * vy) / gravity
+            
+            # Range
+            range_val = vx * time_of_flight
+            
+            # Maximum height
+            max_height = (vy ** 2) / (2 * gravity)
+            
+            return {
+                "initial_velocity": initial_velocity,
+                "angle_degrees": angle_degrees,
+                "velocity_x": vx,
+                "velocity_y": vy,
+                "time_of_flight": time_of_flight,
+                "range": range_val,
+                "max_height": max_height
+            }
+        
+        # Run physics simulations
+        results = []
+        
+        # Test kinetic energy calculations
+        for mass, velocity in [(1.0, 10.0), (2.0, 5.0), (0.5, 20.0)]:
+            ke = calculate_kinetic_energy(mass, velocity)
+            results.append(ke)
+            expected = 0.5 * mass * (velocity ** 2)
+            assert abs(ke - expected) < 1e-10
+        
+        # Test pendulum period calculations
+        for length in [1.0, 2.0, 0.5]:
+            period = calculate_pendulum_period(length)
+            results.append(period)
+            expected = 2 * np.pi * np.sqrt(length / 9.81)
+            assert abs(period - expected) < 1e-10
+        
+        # Test projectile motion simulations
+        projectile_results = []
+        for velocity, angle in [(20.0, 45.0), (30.0, 30.0), (15.0, 60.0)]:
+            trajectory = simulate_projectile_motion(velocity, angle)
+            projectile_results.append(trajectory)
+            
+            # Verify basic physics principles
+            assert trajectory["velocity_x"] > 0
+            assert trajectory["max_height"] > 0
+            assert trajectory["range"] > 0
+        
+        # Flush buffers to ensure all calls are saved
+        postgres_storage.flush()
+        postgres_storage.close()
+        
+        # Verify calls were logged to PostgreSQL
+        connector = postgres_storage.connector
+        connector.connect()
+        
+        time_interval = TimeInterval(start_time=start_time)
+
+        # Check kinetic energy calls
+        ke_calls = connector.load_calls("calculate_kinetic_energy", time_interval=time_interval)
+        assert len(ke_calls) == 3, f"Expected 3 kinetic energy calls, got {len(ke_calls)}"
+        
+        # Check pendulum calls
+        pendulum_calls = connector.load_calls("calculate_pendulum_period", time_interval=time_interval)
+        assert len(pendulum_calls) == 3, f"Expected 3 pendulum calls, got {len(pendulum_calls)}"
+        
+        # Check projectile calls
+        projectile_calls = connector.load_calls("simulate_projectile_motion", time_interval=time_interval)
+        assert len(projectile_calls) == 3, f"Expected 3 projectile calls, got {len(projectile_calls)}"
+        
+        # Verify function names
+        functions = connector.get_all_functions()
+        expected_functions = {"calculate_kinetic_energy", "calculate_pendulum_period", "simulate_projectile_motion"}
+        assert expected_functions.issubset(functions)
+        
+        connector.disconnect()
+        
+        return results, projectile_results

--- a/tests/test_time_interval_filtering.py
+++ b/tests/test_time_interval_filtering.py
@@ -1,0 +1,266 @@
+"""
+Test TimeInterval filtering functionality for load_calls
+"""
+
+import pytest
+import json
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from imitator import monitor_function, LocalStorage
+from imitator.types import TimeInterval, FunctionCall, FunctionSignature, IORecord
+
+
+class TestTimeIntervalFiltering:
+    """Test TimeInterval filtering across multiple days"""
+    
+    def test_load_calls_multi_day_filtering(self):
+        """Test load_calls filtering across multiple days using call_id timestamps"""
+        
+        # Step 1: Create a temporary directory for test logs
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = LocalStorage(log_dir=temp_dir, format="jsonl")
+            
+            # Step 1: Artificially generate logs over 3 days
+            base_time = datetime(2024, 1, 15, 12, 0, 0)  # January 15, 2024 at noon
+            
+            # Day 1 logs (January 15)
+            day1_calls = []
+            for i in range(3):
+                call_time = base_time + timedelta(hours=i)
+                call_id = str(call_time.timestamp())
+                
+                function_call = FunctionCall(
+                    function_signature=FunctionSignature(
+                        name="test_function",
+                        parameters={"x": "int"},
+                        return_type="int"
+                    ),
+                    io_record=IORecord(
+                        inputs={"x": i},
+                        output=i * 2,
+                        timestamp=call_time,
+                        execution_time_ms=10.0
+                    ),
+                    call_id=call_id
+                )
+                day1_calls.append(function_call)
+            
+            # Day 2 logs (January 16)
+            day2_base = base_time + timedelta(days=1)
+            day2_calls = []
+            for i in range(3):
+                call_time = day2_base + timedelta(hours=i)
+                call_id = str(call_time.timestamp())
+                
+                function_call = FunctionCall(
+                    function_signature=FunctionSignature(
+                        name="test_function",
+                        parameters={"x": "int"},
+                        return_type="int"
+                    ),
+                    io_record=IORecord(
+                        inputs={"x": i + 10},
+                        output=(i + 10) * 2,
+                        timestamp=call_time,
+                        execution_time_ms=15.0
+                    ),
+                    call_id=call_id
+                )
+                day2_calls.append(function_call)
+            
+            # Day 3 logs (January 17)
+            day3_base = base_time + timedelta(days=2)
+            day3_calls = []
+            for i in range(3):
+                call_time = day3_base + timedelta(hours=i)
+                call_id = str(call_time.timestamp())
+                
+                function_call = FunctionCall(
+                    function_signature=FunctionSignature(
+                        name="test_function",
+                        parameters={"x": "int"},
+                        return_type="int"
+                    ),
+                    io_record=IORecord(
+                        inputs={"x": i + 20},
+                        output=(i + 20) * 2,
+                        timestamp=call_time,
+                        execution_time_ms=20.0
+                    ),
+                    call_id=call_id
+                )
+                day3_calls.append(function_call)
+            
+            # Write logs to files manually (simulating different days)
+            all_calls = day1_calls + day2_calls + day3_calls
+            
+            # Group calls by date for file writing
+            calls_by_date = {}
+            for call in all_calls:
+                date_str = call.io_record.timestamp.strftime("%Y%m%d")
+                if date_str not in calls_by_date:
+                    calls_by_date[date_str] = []
+                calls_by_date[date_str].append(call)
+            
+            # Write each day's calls to separate files
+            for date_str, calls in calls_by_date.items():
+                log_file = Path(temp_dir) / f"test_function_{date_str}.jsonl"
+                with open(log_file, "w", encoding="utf-8") as f:
+                    for call in calls:
+                        f.write(call.model_dump_json() + "\n")
+            
+            # Step 2: Request to load_calls starting from day 2
+            day2_start = day2_base  # Start of day 2
+            day3_end = day3_base + timedelta(hours=23, minutes=59, seconds=59)  # End of day 3
+            
+            time_interval = TimeInterval(
+                start_time=day2_start,
+                end_time=day3_end
+            )
+            
+            # Load calls with time interval
+            filtered_calls = storage.load_calls("test_function", time_interval=time_interval)
+            
+            # Step 3: Verify that calls from day 1 were not returned
+            # Should only get calls from day 2 and day 3 (6 calls total)
+            assert len(filtered_calls) == 6, f"Expected 6 calls (day 2 + day 3), got {len(filtered_calls)}"
+            
+            # Verify that no calls from day 1 are included
+            day1_call_ids = {call.call_id for call in day1_calls}
+            returned_call_ids = {call.call_id for call in filtered_calls}
+            
+            # Assert no overlap with day 1
+            assert not day1_call_ids.intersection(returned_call_ids), \
+                "Day 1 calls should not be returned when filtering from day 2 onwards"
+            
+            # Verify that day 2 and day 3 calls are included
+            day2_call_ids = {call.call_id for call in day2_calls}
+            day3_call_ids = {call.call_id for call in day3_calls}
+            expected_call_ids = day2_call_ids.union(day3_call_ids)
+            
+            assert returned_call_ids == expected_call_ids, \
+                "Should return exactly the calls from day 2 and day 3"
+            
+            # Verify the calls are ordered by timestamp (call_id)
+            call_timestamps = [float(call.call_id) for call in filtered_calls]
+            assert call_timestamps == sorted(call_timestamps), \
+                "Calls should be ordered by timestamp"
+            
+            # Verify specific input values to ensure correct calls were returned
+            input_values = [call.io_record.inputs["x"] for call in filtered_calls]
+            expected_inputs = [10, 11, 12, 20, 21, 22]  # Day 2: 10,11,12; Day 3: 20,21,22
+            assert input_values == expected_inputs, \
+                f"Expected inputs {expected_inputs}, got {input_values}"
+    
+    def test_load_calls_with_start_time_only(self):
+        """Test load_calls with only start_time (no end_time)"""
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = LocalStorage(log_dir=temp_dir, format="jsonl")
+            
+            # Create calls spanning 2 hours
+            base_time = datetime(2024, 1, 15, 12, 0, 0)
+            all_calls = []
+            
+            for i in range(4):
+                call_time = base_time + timedelta(minutes=30 * i)  # Every 30 minutes
+                call_id = str(call_time.timestamp())
+                
+                function_call = FunctionCall(
+                    function_signature=FunctionSignature(
+                        name="test_function",
+                        parameters={"x": "int"},
+                        return_type="int"
+                    ),
+                    io_record=IORecord(
+                        inputs={"x": i},
+                        output=i * 2,
+                        timestamp=call_time,
+                        execution_time_ms=10.0
+                    ),
+                    call_id=call_id
+                )
+                all_calls.append(function_call)
+            
+            # Write to file
+            date_str = base_time.strftime("%Y%m%d")
+            log_file = Path(temp_dir) / f"test_function_{date_str}.jsonl"
+            with open(log_file, "w", encoding="utf-8") as f:
+                for call in all_calls:
+                    f.write(call.model_dump_json() + "\n")
+            
+            # Request calls starting from 1 hour after base_time (should get last 2 calls)
+            start_time = base_time + timedelta(hours=1)
+            time_interval = TimeInterval(start_time=start_time)  # No end_time
+            
+            filtered_calls = storage.load_calls("test_function", time_interval=time_interval)
+            
+            # Should get the last 2 calls (at 1:00 and 1:30)
+            assert len(filtered_calls) == 2, f"Expected 2 calls, got {len(filtered_calls)}"
+            
+            # Verify correct calls were returned
+            input_values = [call.io_record.inputs["x"] for call in filtered_calls]
+            assert input_values == [2, 3], f"Expected inputs [2, 3], got {input_values}"
+
+    def test_load_calls_no_time_interval_uses_default(self):
+        """Test that load_calls without time_interval uses default (last 1 hour)"""
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = LocalStorage(log_dir=temp_dir, format="jsonl")
+            
+            # Create calls: some old (2 hours ago) and some recent (30 minutes ago)
+            now = datetime.now()
+            old_time = now - timedelta(hours=2)
+            recent_time = now - timedelta(minutes=30)
+            
+            calls = []
+            
+            # Old call (should not be returned with default 1-hour window)
+            old_call = FunctionCall(
+                function_signature=FunctionSignature(
+                    name="test_function",
+                    parameters={"x": "int"},
+                    return_type="int"
+                ),
+                io_record=IORecord(
+                    inputs={"x": 1},
+                    output=2,
+                    timestamp=old_time,
+                    execution_time_ms=10.0
+                ),
+                call_id=str(old_time.timestamp())
+            )
+            calls.append(old_call)
+            
+            # Recent call (should be returned)
+            recent_call = FunctionCall(
+                function_signature=FunctionSignature(
+                    name="test_function",
+                    parameters={"x": "int"},
+                    return_type="int"
+                ),
+                io_record=IORecord(
+                    inputs={"x": 2},
+                    output=4,
+                    timestamp=recent_time,
+                    execution_time_ms=10.0
+                ),
+                call_id=str(recent_time.timestamp())
+            )
+            calls.append(recent_call)
+            
+            # Write to file
+            date_str = now.strftime("%Y%m%d")
+            log_file = Path(temp_dir) / f"test_function_{date_str}.jsonl"
+            with open(log_file, "w", encoding="utf-8") as f:
+                for call in calls:
+                    f.write(call.model_dump_json() + "\n")
+            
+            # Load calls without specifying time_interval (should use default)
+            filtered_calls = storage.load_calls("test_function")
+            
+            # Should only get the recent call (within last hour)
+            assert len(filtered_calls) == 1, f"Expected 1 call, got {len(filtered_calls)}"
+            assert filtered_calls[0].io_record.inputs["x"] == 2, \
+                "Should return the recent call, not the old one"


### PR DESCRIPTION
### Merge Request Summary — Database integration and tooling

- **Purpose**: Add optional database streaming support (PostgreSQL, MongoDB, Couchbase) and local dev tooling, plus docs and minor DX tweaks.

### Highlights
- **New docker-compose for local DBs**
  - Added `docker-compose.db.yml` to spin up PostgreSQL, MongoDB, and Couchbase with volumes and healthchecks.
- **Makefile updates**
  - Switched tests to `python3` in `test` target.
  - Added `db-*` targets: `db-start`, `db-stop`, `db-test`, `db-install`, `db-clean`, and `db-physics-test`.
- **Docs**
  - Added a “Database Integration” section to `README.md`: setup, connection strings, examples for all three connectors, and dependency install guidance.
- **Public API surface**
  - `imitator/__init__.py`: now exports `DatabaseStorage`, `PostgreSQLConnector`, `MongoDBConnector`, `CouchbaseConnector`, alongside existing symbols.
  - `imitator/monitor.py`: imports and re-exports `LocalStorage`, `DatabaseStorage`, and all three connectors via `__all__`.

### Developer impact
- **Opt-in**: Database features are optional; core usage remains unchanged.
- **Convenience**: One-command local DB setup via Makefile; example usage included in README.
- **Dependencies**: New optional extras (`psycopg2-binary`, `pymongo`, `couchbase`) installed with `make db-install`.

### How to test locally
- Start services: `make db-start`
- Verify connections: `make db-test`
- Install deps: `make db-install`
- Run tests: `make test`
- Optional: try the README’s database examples.

### Compatibility / risk
- **Backward compatible**: No breaking changes expected; existing imports continue to work.
- **Ports in use**: 5432 (Postgres), 27017 (MongoDB), 8091–8097/18091–18097 (Couchbase).
- **Couchbase**: UI/manual verification recommended at `http://localhost:8091`.

- Added `docker-compose.db.yml`
- Extended `Makefile` with db targets and switched test runner to `python3`
- Expanded `README.md` with database setup and usage examples
- Broadened public API exports in `imitator/__init__.py` and `imitator/monitor.py`